### PR TITLE
fix: use url.UserPassword to safely encode connection string credentials

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log/slog"
 	"net"
+	"net/url"
 	"os"
 	"os/signal"
 	"strings"
@@ -172,8 +173,7 @@ func handleConnection(ctx context.Context, clientConn net.Conn, dbHost string, a
 
 	l.Info("obtained Azure Entra token", "expiresAt", token.ExpiresOn)
 
-	connStr := fmt.Sprintf("postgres://%s:%s@%s/%s?sslmode=require", clientUser, token.Token, dbHost, clientDatabase)
-	config, err := pgconn.ParseConfig(connStr)
+	config, err := buildConfig(clientUser, token.Token, dbHost, clientDatabase)
 	if err != nil {
 		l.Error("failed to parse connection string", "error", err)
 		return
@@ -252,6 +252,17 @@ func handleConnection(ctx context.Context, clientConn net.Conn, dbHost string, a
 	wg.Wait()
 
 	l.Info("proxy connection closed", "clientAddr", clientConn.RemoteAddr(), "backendAddr", backendNetConn.RemoteAddr())
+}
+
+func buildConfig(user, password, host, database string) (*pgconn.Config, error) {
+	u := &url.URL{
+		Scheme:   "postgres",
+		User:     url.UserPassword(user, password),
+		Host:     host,
+		Path:     database,
+		RawQuery: "sslmode=require",
+	}
+	return pgconn.ParseConfig(u.String())
 }
 
 // simulateClientHandshake simulates the PostgreSQL handshake between the client and the backend.

--- a/main_test.go
+++ b/main_test.go
@@ -359,3 +359,30 @@ func startProxyAndConnect(t *testing.T, ctx context.Context, dbHost string, cfg 
 
 	return conn
 }
+
+func TestConnStrWithSpecialCharacters(t *testing.T) {
+	tests := []struct {
+		name     string
+		user     string
+		password string
+		host     string
+		database string
+	}{
+		{"plain username", "johndoe", "token123", "localhost:5432", "mydb"},
+		{"plain with numbers", "user123", "token123", "localhost:5432", "mydb"},
+		{"space in username", "john doe", "token123", "localhost:5432", "mydb"},
+		{"colon", "john:doe", "token123", "localhost:5432", "mydb"},
+		{"special chars in password", "johndoe", "tok en+x=y&z", "localhost:5432", "mydb"},
+		{"email as username", "john.doe@example.com", "token123", "localhost:5432", "mydb"},
+		{"unicode username", "jøhn", "token123", "localhost:5432", "mydb"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := buildConfig(tt.user, tt.password, tt.host, tt.database)
+			if err != nil {
+				t.Errorf("expected no error for user %q, got: %v", tt.user, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Using `fmt.Sprintf` to build the connection URL did not encode special characters in the userinfo portion, causing pgconn.ParseConfig to fail for usernames containing spaces, @, : or other reserved chars.

Fixes #51