### PR TITLE
fix: forward server ParameterStatuses during client handshake

### DIFF
--- a/main.go
+++ b/main.go
@@ -271,11 +271,21 @@ func simulateClientHandshake(clientConn net.Conn, hijackedBackend *pgconn.Hijack
 	handshakeMessages := []pgproto3.BackendMessage{
 		&pgproto3.AuthenticationOk{},
 	}
-	for k, v := range hijackedBackend.Config.RuntimeParams {
+	// Send server parameters from ParameterStatuses (includes server_version, etc.)
+	for k, v := range hijackedBackend.ParameterStatuses {
 		handshakeMessages = append(handshakeMessages, &pgproto3.ParameterStatus{
 			Name:  k,
 			Value: v,
 		})
+	}
+	// Send any additional client-provided runtime params not already sent
+	for k, v := range hijackedBackend.Config.RuntimeParams {
+		if _, exists := hijackedBackend.ParameterStatuses[k]; !exists {
+			handshakeMessages = append(handshakeMessages, &pgproto3.ParameterStatus{
+				Name:  k,
+				Value: v,
+			})
+		}
 	}
 	handshakeMessages = append(handshakeMessages, &pgproto3.BackendKeyData{
 		ProcessID: uint32(hijackedBackend.PID),


### PR DESCRIPTION
## Summary
- The simulated handshake replayed `Config.RuntimeParams` (client-supplied startup params) but never `HijackedConn.ParameterStatuses` (server-reported params like `server_version`, `server_encoding`, `DateStyle`).
- Clients that parse those values saw nil/empty and failed — Postgrex crashed in `parse_version/1`, pgAdmin fell back to a legacy catalog path and hit `column rel.relhasoids does not exist`.
- Send `ParameterStatuses` first, then fill in any `RuntimeParams` the server didn't echo, so authoritative server values win without dropping client-side runtime settings.

Fixes #44

## Test plan
- [x] Built a container with this change, deployed to Kubernetes, confirmed an Elixir/Phoenix + Postgrex app connects and queries successfully (logs in #44).
- [ ] Reviewer: sanity-check against a non-Elixir client (psql / pgAdmin) if convenient.